### PR TITLE
feat: add mTLS support for secure ADB connection through nginx reverse proxy

### DIFF
--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/nativecore/DirectAdbClient.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/nativecore/DirectAdbClient.kt
@@ -54,14 +54,15 @@ internal object DirectAdbTransport {
     @Volatile
     var keyName: String = AppSettings.ADB_KEY_NAME.defaultValue
 
-    fun connect(host: String, port: Int): DirectAdbConnection {
-        Log.i(TAG, "connect(): opening direct adbd transport to $host:$port")
+    fun connect(host: String, port: Int, mtlsConfig: MtlsConfig? = null): DirectAdbConnection {
+        Log.i(TAG, "connect(): opening direct adbd transport to $host:$port (mtls=${mtlsConfig != null})")
         val conn = DirectAdbConnection(
             host,
             port,
             privateKey,
             publicKeyX509,
             keyName.ifBlank { AppSettings.ADB_KEY_NAME.defaultValue },
+            mtlsConfig,
         )
         conn.handshake()
         Log.i(TAG, "connect(): handshake success for $host:$port")
@@ -528,6 +529,7 @@ internal class DirectAdbConnection(
     private val privateKey: PrivateKey,
     private val publicKeyX509: ByteArray,
     private val keyName: String = AppSettings.ADB_KEY_NAME.defaultValue,
+    private val mtlsConfig: MtlsConfig? = null,
 ): AutoCloseable {
 
     private val sha1DigestInfoPrefix = byteArrayOf(
@@ -580,10 +582,14 @@ internal class DirectAdbConnection(
         rawIn = BufferedInputStream(socket.getInputStream(), 65_536)
         rawOut = socket.getOutputStream()
 
+        if (mtlsConfig != null) {
+            upgradeToMtls(mtlsConfig)
+        }
+
         sendMsg(A_CNXN, VERSION, MAX_PAYLOAD, "host::\u0000".toByteArray(Charsets.UTF_8))
 
         var first = recvMsg()
-        if (first.command == A_STLS) {
+        if (first.command == A_STLS && mtlsConfig == null) {
             sendMsg(A_STLS, STLS_VERSION, 0)
             upgradeToTls()
             first = recvMsg()
@@ -633,6 +639,15 @@ internal class DirectAdbConnection(
             alias = keyName,
         )
         val sslSocket = pairingKey.sslContext.socketFactory
+            .createSocket(socket, host, port, true) as SSLSocket
+        sslSocket.startHandshake()
+        tlsSocket = sslSocket
+        rawIn = BufferedInputStream(sslSocket.inputStream, 65_536)
+        rawOut = sslSocket.outputStream
+    }
+
+    private fun upgradeToMtls(mtlsConfig: MtlsConfig) {
+        val sslSocket = mtlsConfig.sslContext.socketFactory
             .createSocket(socket, host, port, true) as SSLSocket
         sslSocket.startHandshake()
         tlsSocket = sslSocket
@@ -854,6 +869,9 @@ internal class DirectAdbConnection(
         val dataLen = buf.int
         buf.int
         buf.int
+        if (dataLen < 0 || dataLen > MAX_PAYLOAD) {
+            throw IOException("ADB: invalid data length $dataLen (possibly non-ADB traffic, check if mTLS is required)")
+        }
         val data =
             if (dataLen > 0) ByteArray(dataLen).also { rawIn.readExact(it) } else ByteArray(0)
         return AdbMsg(command, arg0, arg1, data)

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/nativecore/MtlsConfig.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/nativecore/MtlsConfig.kt
@@ -1,0 +1,282 @@
+package io.github.miuzarte.scrcpyforandroid.nativecore
+
+import android.annotation.SuppressLint
+import android.util.Base64
+import android.util.Log
+import org.conscrypt.Conscrypt
+import java.io.ByteArrayInputStream
+import java.security.*
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.interfaces.RSAPrivateCrtKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.RSAPrivateCrtKeySpec
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.X509ExtendedTrustManager
+
+/**
+ * mTLS configuration that holds CA certificate, client certificate chain,
+ * and client private key. Builds an [SSLContext] for mutual TLS authentication.
+ */
+class MtlsConfig private constructor(
+    private val caCertificate: X509Certificate,
+    private val clientCertificate: X509Certificate,
+    private val clientPrivateKey: PrivateKey,
+) {
+
+    val sslContext: SSLContext by lazy {
+        val conscryptProvider: Provider = Conscrypt.newProviderBuilder().build()
+        if (Security.getProvider(conscryptProvider.name) == null) {
+            Security.insertProviderAt(conscryptProvider, 1)
+        }
+        val context = SSLContext.getInstance("TLSv1.3", conscryptProvider)
+        context.init(arrayOf(keyManager), arrayOf(trustManager), SecureRandom())
+        context
+    }
+
+    private val keyManager: X509ExtendedKeyManager
+        get() = object: X509ExtendedKeyManager() {
+            private val keyAlias = "mtls-client"
+
+            override fun chooseClientAlias(
+                keyType: Array<out String>?,
+                issuers: Array<out java.security.Principal>?,
+                socket: java.net.Socket?,
+            ): String = keyAlias
+
+            override fun getCertificateChain(alias: String?): Array<X509Certificate>? {
+                return if (alias == keyAlias) arrayOf(clientCertificate) else null
+            }
+
+            override fun getPrivateKey(alias: String?): PrivateKey? {
+                return if (alias == keyAlias) clientPrivateKey else null
+            }
+
+            override fun getClientAliases(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+            ): Array<String>? = null
+
+            override fun getServerAliases(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+            ): Array<String>? = null
+
+            override fun chooseServerAlias(
+                keyType: String?,
+                issuers: Array<out java.security.Principal>?,
+                socket: java.net.Socket?,
+            ): String? = null
+        }
+
+    @get:SuppressLint("CustomX509TrustManager")
+    private val trustManager: X509ExtendedTrustManager
+        get() = object: X509ExtendedTrustManager() {
+
+            private fun validateCertificate(chain: Array<out X509Certificate>?) {
+                if (chain.isNullOrEmpty()) {
+                    throw java.security.cert.CertificateException("Empty certificate chain")
+                }
+                val cert = chain[0]
+                cert.checkValidity()
+                if (cert.issuerX500Principal != caCertificate.subjectX500Principal) {
+                    throw java.security.cert.CertificateException(
+                        "Certificate issuer mismatch: got ${cert.issuerX500Principal}, expected ${caCertificate.subjectX500Principal}"
+                    )
+                }
+            }
+
+            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: java.net.Socket?) {
+                validateCertificate(chain)
+            }
+
+            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?, engine: SSLEngine?) {
+                validateCertificate(chain)
+            }
+
+            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+                validateCertificate(chain)
+            }
+
+            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: java.net.Socket?) {
+                validateCertificate(chain)
+            }
+
+            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, engine: SSLEngine?) {
+                validateCertificate(chain)
+            }
+
+            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+                validateCertificate(chain)
+            }
+
+            override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf(caCertificate)
+        }
+
+    companion object {
+        private const val TAG = "MtlsConfig"
+
+        /**
+         * Build [MtlsConfig] from PEM-encoded strings.
+         */
+        fun fromPem(
+            caCertPem: String,
+            clientCertPem: String,
+            clientKeyPem: String,
+        ): MtlsConfig {
+            val caCert = parseX509Certificate(caCertPem)
+            val clientCert = parseX509Certificate(clientCertPem)
+            val clientKey = parsePrivateKey(clientKeyPem)
+            Log.i(TAG, "fromPem(): ca=${fingerprint(caCert.encoded)}, client=${fingerprint(clientCert.encoded)}")
+            return MtlsConfig(caCert, clientCert, clientKey)
+        }
+
+        /**
+         * Build [MtlsConfig] from a PKCS12 keystore and a CA certificate PEM.
+         */
+        fun fromPkcs12(
+            caCertPem: String,
+            pkcs12Bytes: ByteArray,
+            password: String = "",
+        ): MtlsConfig {
+            val caCert = parseX509Certificate(caCertPem)
+            val ks = java.security.KeyStore.getInstance("PKCS12")
+            ks.load(ByteArrayInputStream(pkcs12Bytes), password.toCharArray())
+            val alias = ks.aliases().asSequence().firstOrNull()
+                ?: throw IllegalArgumentException("PKCS12 contains no entries")
+            val clientCert = ks.getCertificate(alias) as? X509Certificate
+                ?: throw IllegalArgumentException("PKCS12 entry is not an X509 certificate")
+            val clientKey = ks.getKey(alias, password.toCharArray()) as? PrivateKey
+                ?: throw IllegalArgumentException("PKCS12 entry has no private key")
+            Log.i(TAG, "fromPkcs12(): ca=${fingerprint(caCert.encoded)}, client=${fingerprint(clientCert.encoded)}")
+            return MtlsConfig(caCert, clientCert, clientKey)
+        }
+
+        /**
+         * Extract client certificate and private key PEM from a PKCS12 keystore.
+         * Returns (certPem, keyPem).
+         */
+        fun extractPemFromPkcs12(
+            pkcs12Bytes: ByteArray,
+            password: String = "",
+        ): Pair<String, String> {
+            val ks = java.security.KeyStore.getInstance("PKCS12")
+            ks.load(ByteArrayInputStream(pkcs12Bytes), password.toCharArray())
+            val alias = ks.aliases().asSequence().firstOrNull()
+                ?: throw IllegalArgumentException("PKCS12 contains no entries")
+            val cert = ks.getCertificate(alias) as? X509Certificate
+                ?: throw IllegalArgumentException("PKCS12 entry is not an X509 certificate")
+            val key = ks.getKey(alias, password.toCharArray()) as? PrivateKey
+                ?: throw IllegalArgumentException("PKCS12 entry has no private key")
+            val certPem = "-----BEGIN CERTIFICATE-----\n" +
+                android.util.Base64.encodeToString(cert.encoded, android.util.Base64.NO_WRAP) +
+                "\n-----END CERTIFICATE-----"
+            val keyPem = "-----BEGIN PRIVATE KEY-----\n" +
+                android.util.Base64.encodeToString(key.encoded, android.util.Base64.NO_WRAP) +
+                "\n-----END PRIVATE KEY-----"
+            return Pair(certPem, keyPem)
+        }
+
+        private fun parseX509Certificate(pem: String): X509Certificate {
+            val der = pemToDer(pem)
+            val cf = CertificateFactory.getInstance("X.509")
+            return cf.generateCertificate(ByteArrayInputStream(der)) as X509Certificate
+        }
+
+        private fun parsePrivateKey(pem: String): PrivateKey {
+            val kf = KeyFactory.getInstance("RSA")
+            val pemBlock = readPem(pem)
+            return when (pemBlock?.label) {
+                "RSA PRIVATE KEY" -> {
+                    val spec = parsePkcs1PrivateKey(pemBlock.bytes)
+                    kf.generatePrivate(spec)
+                }
+                "PRIVATE KEY", null -> {
+                    val der = pemBlock?.bytes ?: Base64.decode(
+                        pem.filterNot(Char::isWhitespace), Base64.DEFAULT
+                    )
+                    kf.generatePrivate(PKCS8EncodedKeySpec(der))
+                }
+                else -> throw IllegalArgumentException("Unsupported private key format: ${pemBlock.label}")
+            }
+        }
+
+        private fun pemToDer(pem: String): ByteArray {
+            val pemBlock = readPem(pem) ?: return Base64.decode(
+                pem.filterNot(Char::isWhitespace), Base64.DEFAULT
+            )
+            return pemBlock.bytes
+        }
+
+        private data class PemBlock(val label: String, val bytes: ByteArray)
+
+        private fun readPem(content: String): PemBlock? {
+            val begin = Regex("-----BEGIN ([A-Z0-9 ]+)-----").find(content) ?: return null
+            val label = begin.groupValues[1]
+            val endMarker = "-----END $label-----"
+            val end = content.indexOf(endMarker, begin.range.last + 1)
+            require(end >= 0) { "Invalid PEM: missing END $label" }
+            val body = content.substring(begin.range.last + 1, end)
+            return PemBlock(label, Base64.decode(body.filterNot(Char::isWhitespace), Base64.DEFAULT))
+        }
+
+        private fun parsePkcs1PrivateKey(der: ByteArray): RSAPrivateCrtKeySpec {
+            val reader = DerReader(der).readSequence()
+            reader.readInteger() // version
+            val modulus = reader.readInteger()
+            val publicExponent = reader.readInteger()
+            val privateExponent = reader.readInteger()
+            val primeP = reader.readInteger()
+            val primeQ = reader.readInteger()
+            val primeExponentP = reader.readInteger()
+            val primeExponentQ = reader.readInteger()
+            val crtCoefficient = reader.readInteger()
+            return RSAPrivateCrtKeySpec(
+                modulus, publicExponent, privateExponent,
+                primeP, primeQ, primeExponentP, primeExponentQ, crtCoefficient,
+            )
+        }
+
+        private fun fingerprint(certDer: ByteArray): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(certDer)
+            return digest.joinToString(":") { b -> "%02x".format(b) }
+        }
+    }
+}
+
+private class DerReader(private val bytes: ByteArray) {
+    private var offset = 0
+
+    fun readSequence(): DerReader {
+        val content = readTag(0x30)
+        return DerReader(content)
+    }
+
+    fun readInteger(): java.math.BigInteger =
+        java.math.BigInteger(readTag(0x02))
+
+    private fun readTag(expectedTag: Int): ByteArray {
+        require(offset < bytes.size) { "Invalid ASN.1 DER" }
+        val tag = bytes[offset++].toInt() and 0xff
+        require(tag == expectedTag) { "Unsupported ASN.1 DER key format" }
+        val length = readLength()
+        require(offset + length <= bytes.size) { "Invalid ASN.1 DER length" }
+        return bytes.copyOfRange(offset, offset + length).also {
+            offset += length
+        }
+    }
+
+    private fun readLength(): Int {
+        val first = bytes[offset++].toInt() and 0xff
+        if (first < 0x80) return first
+        val lengthBytes = first and 0x7f
+        require(lengthBytes in 1..4) { "Unsupported ASN.1 DER length" }
+        var length = 0
+        repeat(lengthBytes) {
+            length = (length shl 8) or (bytes[offset++].toInt() and 0xff)
+        }
+        return length
+    }
+}

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/nativecore/NativeAdbService.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/nativecore/NativeAdbService.kt
@@ -87,10 +87,11 @@ object NativeAdbService {
     suspend fun connect(
         host: String,
         port: Int,
+        mtlsConfig: MtlsConfig? = null,
         timeout: Duration = Duration.INFINITE,
     ) = withContext(Dispatchers.IO) {
         mutex.withLock {
-            Log.i(TAG, "connect(): host=$host port=$port")
+            Log.i(TAG, "connect(): host=$host port=$port mtls=${mtlsConfig != null}")
 
             if (connection != null
                 && connection!!.isAlive()
@@ -102,7 +103,7 @@ object NativeAdbService {
             disconnectInternal()
 
             try {
-                val conn = withTimeout(timeout) { transport.connect(host, port) }
+                val conn = withTimeout(timeout) { transport.connect(host, port, mtlsConfig) }
                 connection = conn
                 connectedHost = host
                 connectedPort = port

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/pages/DeviceTabViewModel.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/pages/DeviceTabViewModel.kt
@@ -11,12 +11,14 @@ import io.github.miuzarte.scrcpyforandroid.models.ConnectionTarget
 import io.github.miuzarte.scrcpyforandroid.models.DeviceShortcut
 import io.github.miuzarte.scrcpyforandroid.models.DeviceShortcuts
 import io.github.miuzarte.scrcpyforandroid.scrcpy.Scrcpy
+import io.github.miuzarte.scrcpyforandroid.nativecore.MtlsConfig
 import io.github.miuzarte.scrcpyforandroid.services.*
 import io.github.miuzarte.scrcpyforandroid.services.EventLogger.logEvent
 import io.github.miuzarte.scrcpyforandroid.storage.AppSettings
 import io.github.miuzarte.scrcpyforandroid.storage.ScrcpyOptions
 import io.github.miuzarte.scrcpyforandroid.storage.Settings
 import io.github.miuzarte.scrcpyforandroid.storage.Storage.appSettings
+import io.github.miuzarte.scrcpyforandroid.storage.Storage.mtlsData
 import io.github.miuzarte.scrcpyforandroid.storage.Storage.quickDevices
 import io.github.miuzarte.scrcpyforandroid.storage.Storage.scrcpyOptions
 import io.github.miuzarte.scrcpyforandroid.storage.Storage.scrcpyProfiles
@@ -489,11 +491,23 @@ internal class DeviceTabViewModel(
     }
 
     suspend fun connectWithTimeout(host: String, port: Int) {
-        connectionController.connectWithTimeout(host, port, ADB_CONNECT_TIMEOUT_MS)
+        val mtls = try {
+            buildMtlsConfigIfEnabled()
+        } catch (e: Exception) {
+            AppRuntime.snackbar(R.string.pref_mtls_import_failed, e.message ?: e.javaClass.simpleName)
+            return
+        }
+        connectionController.connectWithTimeout(host, port, ADB_CONNECT_TIMEOUT_MS, mtls)
     }
 
     suspend fun connectAddresses(addresses: List<String>): ConnectionTarget {
-        return connectionController.connectAddresses(addresses, ADB_CONNECT_TIMEOUT_MS, ADB_TCP_PROBE_TIMEOUT_MS)
+        val mtls = try {
+            buildMtlsConfigIfEnabled()
+        } catch (e: Exception) {
+            AppRuntime.snackbar(R.string.pref_mtls_import_failed, e.message ?: e.javaClass.simpleName)
+            throw e
+        }
+        return connectionController.connectAddresses(addresses, ADB_CONNECT_TIMEOUT_MS, ADB_TCP_PROBE_TIMEOUT_MS, mtls)
     }
 
     suspend fun disconnectCurrentTargetBeforeConnectingAny(addresses: List<String>) {
@@ -985,6 +999,20 @@ internal class DeviceTabViewModel(
 
     suspend fun startAppViaAdb(packageName: String) {
         adbCoordinator.startApp(packageName = packageName)
+    }
+
+    private suspend fun buildMtlsConfigIfEnabled(): MtlsConfig? {
+        val settings = appSettings.bundleState.value
+        if (!settings.mtlsEnabled) return null
+        val data = mtlsData.bundleState.value
+        val ca = data.caCertificate.takeIf { it.isNotBlank() }
+            ?: throw IllegalStateException("mTLS enabled but CA certificate not imported")
+        val clientCert = data.clientCertificate.takeIf { it.isNotBlank() }
+        val clientKey = data.clientPrivateKey.takeIf { it.isNotBlank() }
+        if (clientCert == null || clientKey == null) {
+            throw IllegalStateException("mTLS enabled but client certificate not imported")
+        }
+        return MtlsConfig.fromPem(ca, clientCert, clientKey)
     }
 
     class Factory(

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/pages/SettingsScreen.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/pages/SettingsScreen.kt
@@ -31,6 +31,7 @@ import io.github.miuzarte.scrcpyforandroid.MainActivity
 import io.github.miuzarte.scrcpyforandroid.R
 import io.github.miuzarte.scrcpyforandroid.constants.UiSpacing
 import io.github.miuzarte.scrcpyforandroid.nativecore.DirectAdbTransport
+import io.github.miuzarte.scrcpyforandroid.nativecore.MtlsConfig
 import io.github.miuzarte.scrcpyforandroid.scaffolds.ArrowSlider
 import io.github.miuzarte.scrcpyforandroid.scaffolds.LazyColumn
 import io.github.miuzarte.scrcpyforandroid.scaffolds.SectionSmallTitle
@@ -43,6 +44,7 @@ import io.github.miuzarte.scrcpyforandroid.storage.AppSettings.FullscreenVirtual
 import io.github.miuzarte.scrcpyforandroid.storage.Settings
 import io.github.miuzarte.scrcpyforandroid.storage.Storage.adbClientData
 import io.github.miuzarte.scrcpyforandroid.storage.Storage.appSettings
+import io.github.miuzarte.scrcpyforandroid.storage.Storage.mtlsData
 import io.github.miuzarte.scrcpyforandroid.ui.*
 import kotlinx.coroutines.*
 import top.yukonga.miuix.kmp.basic.*
@@ -78,6 +80,12 @@ suspend fun clearTerminalFont(context: Context) =
 suspend fun readTextFromUri(context: Context, uri: Uri): String =
     withContext(Dispatchers.IO) {
         context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+            ?: error("Cannot open selected file")
+    }
+
+suspend fun readBytesFromUri(context: Context, uri: Uri): ByteArray =
+    withContext(Dispatchers.IO) {
+        context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
             ?: error("Cannot open selected file")
     }
 
@@ -1060,6 +1068,204 @@ fun SettingsPage(
                         )
                     },
                 )
+            }
+        }
+
+        item {
+            SectionSmallTitle(stringResource(R.string.section_mtls))
+            Card {
+                val mtlsBundle by mtlsData.bundleState.collectAsState()
+
+                SwitchPreference(
+                    title = stringResource(R.string.pref_title_mtls_enabled),
+                    summary = stringResource(R.string.pref_summary_mtls_enabled),
+                    checked = asBundle.mtlsEnabled,
+                    onCheckedChange = {
+                        asBundle = asBundle.copy(mtlsEnabled = it)
+                    },
+                )
+
+                val mtlsCaPicker = rememberLauncherForActivityResult(
+                    ActivityResultContracts.OpenDocument(),
+                ) { uri: Uri? ->
+                    if (uri == null) return@rememberLauncherForActivityResult
+                    scope.launch {
+                        runCatching {
+                            val fileName = queryAdbKeyDisplayName(context, uri)
+                                ?.takeIf { it.isNotBlank() }
+                                ?: uri.lastPathSegment.orEmpty()
+                            val content = readTextFromUri(context, uri)
+                            mtlsData.saveBundle(
+                                mtlsBundle.copy(
+                                    caCertificate = content,
+                                    caCertificateFileName = fileName,
+                                )
+                            )
+                            fileName
+                        }.onSuccess {
+                            AppRuntime.snackbar(R.string.pref_mtls_ca_imported, it)
+                        }.onFailure { e ->
+                            AppRuntime.snackbar(
+                                R.string.pref_mtls_import_failed,
+                                e.message ?: e.javaClass.simpleName,
+                            )
+                        }
+                    }
+                }
+
+                val mtlsPkcs12Picker = rememberLauncherForActivityResult(
+                    ActivityResultContracts.OpenDocument(),
+                ) { uri: Uri? ->
+                    if (uri == null) return@rememberLauncherForActivityResult
+                    scope.launch {
+                        runCatching {
+                            val fileName = queryAdbKeyDisplayName(context, uri)
+                                ?.takeIf { it.isNotBlank() }
+                                ?: uri.lastPathSegment.orEmpty()
+                            val pkcs12Bytes = readBytesFromUri(context, uri)
+                            val ca = mtlsBundle.caCertificate
+                            require(ca.isNotBlank()) { "Import CA certificate first" }
+                            val (certPem, keyPem) = MtlsConfig.extractPemFromPkcs12(pkcs12Bytes)
+                            MtlsConfig.fromPkcs12(ca, pkcs12Bytes)
+                            mtlsData.saveBundle(
+                                mtlsBundle.copy(
+                                    clientCertificate = certPem,
+                                    clientPrivateKey = keyPem,
+                                    clientCertFileName = fileName,
+                                    clientKeyFileName = "",
+                                )
+                            )
+                            fileName
+                        }.onSuccess {
+                            AppRuntime.snackbar(R.string.pref_mtls_pkcs12_imported, it)
+                        }.onFailure { e ->
+                            AppRuntime.snackbar(
+                                R.string.pref_mtls_import_failed,
+                                e.message ?: e.javaClass.simpleName,
+                            )
+                        }
+                    }
+                }
+
+                Column(
+                    modifier = Modifier.padding(vertical = UiSpacing.Large),
+                    verticalArrangement = Arrangement.spacedBy(UiSpacing.ContentVertical),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = UiSpacing.Large),
+                        verticalArrangement = Arrangement.spacedBy(UiSpacing.Medium),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.pref_title_mtls_ca_cert),
+                            fontWeight = FontWeight.Medium,
+                        )
+                        TextField(
+                            value = mtlsBundle.caCertificateFileName,
+                            onValueChange = {},
+                            readOnly = true,
+                            label = stringResource(
+                                if (mtlsBundle.caCertificate.isBlank()) R.string.pref_mtls_not_imported
+                                else R.string.pref_mtls_imported
+                            ),
+                            useLabelAsPlaceholder = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            trailingIcon = {
+                                Row(modifier = Modifier.padding(end = UiSpacing.Medium)) {
+                                    if (mtlsBundle.caCertificate.isNotBlank()) {
+                                        IconButton(
+                                            onClick = {
+                                                haptic.contextClick()
+                                                scope.launch {
+                                                    mtlsData.saveBundle(
+                                                        mtlsBundle.copy(
+                                                            caCertificate = "",
+                                                            caCertificateFileName = "",
+                                                        )
+                                                    )
+                                                    AppRuntime.snackbar(R.string.pref_mtls_certs_cleared)
+                                                }
+                                            },
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Rounded.Clear,
+                                                contentDescription = stringResource(R.string.cd_clear),
+                                            )
+                                        }
+                                    }
+                                    IconButton(
+                                        onClick = {
+                                            haptic.contextClick()
+                                            mtlsCaPicker.launch(arrayOf("*/*"))
+                                        },
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.FileOpen,
+                                            contentDescription = stringResource(R.string.cd_select_file),
+                                        )
+                                    }
+                                }
+                            },
+                        )
+                    }
+                    Column(
+                        modifier = Modifier.padding(horizontal = UiSpacing.Large),
+                        verticalArrangement = Arrangement.spacedBy(UiSpacing.Medium),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.pref_title_mtls_client_cert),
+                            fontWeight = FontWeight.Medium,
+                        )
+                        TextField(
+                            value = mtlsBundle.clientCertFileName,
+                            onValueChange = {},
+                            readOnly = true,
+                            label = stringResource(
+                                if (mtlsBundle.clientCertificate.isBlank()) R.string.pref_mtls_not_imported
+                                else R.string.pref_mtls_imported
+                            ),
+                            useLabelAsPlaceholder = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            trailingIcon = {
+                                Row(modifier = Modifier.padding(end = UiSpacing.Medium)) {
+                                    if (mtlsBundle.clientCertificate.isNotBlank()) {
+                                        IconButton(
+                                            onClick = {
+                                                haptic.contextClick()
+                                                scope.launch {
+                                                    mtlsData.saveBundle(
+                                                        mtlsBundle.copy(
+                                                            clientCertificate = "",
+                                                            clientPrivateKey = "",
+                                                            clientCertFileName = "",
+                                                            clientKeyFileName = "",
+                                                        )
+                                                    )
+                                                    AppRuntime.snackbar(R.string.pref_mtls_certs_cleared)
+                                                }
+                                            },
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Rounded.Clear,
+                                                contentDescription = stringResource(R.string.cd_clear),
+                                            )
+                                        }
+                                    }
+                                    IconButton(
+                                        onClick = {
+                                            haptic.contextClick()
+                                            mtlsPkcs12Picker.launch(arrayOf("*/*"))
+                                        },
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.FileOpen,
+                                            contentDescription = stringResource(R.string.cd_select_file),
+                                        )
+                                    }
+                                }
+                            },
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/services/ConnectionController.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/services/ConnectionController.kt
@@ -1,6 +1,7 @@
 package io.github.miuzarte.scrcpyforandroid.services
 
 import io.github.miuzarte.scrcpyforandroid.models.ConnectionTarget
+import io.github.miuzarte.scrcpyforandroid.nativecore.MtlsConfig
 import io.github.miuzarte.scrcpyforandroid.scrcpy.Scrcpy
 import io.github.miuzarte.scrcpyforandroid.storage.ScrcpyOptions
 
@@ -65,16 +66,17 @@ internal class ConnectionController(
         }
     }
 
-    suspend fun connectWithTimeout(host: String, port: Int, timeoutMs: Long) {
-        adbCoordinator.connectWithTimeout(host, port, timeoutMs)
+    suspend fun connectWithTimeout(host: String, port: Int, timeoutMs: Long, mtlsConfig: MtlsConfig? = null) {
+        adbCoordinator.connectWithTimeout(host, port, timeoutMs, mtlsConfig)
     }
 
     suspend fun connectAddresses(
         addresses: List<String>,
         timeoutMs: Long,
         probeTimeoutMs: Int,
+        mtlsConfig: MtlsConfig? = null,
     ): ConnectionTarget {
-        return adbCoordinator.connectFirstReachable(addresses, timeoutMs, probeTimeoutMs)
+        return adbCoordinator.connectFirstReachable(addresses, timeoutMs, probeTimeoutMs, mtlsConfig)
     }
 
     suspend fun disconnectCurrentTargetBeforeConnectingAny(
@@ -106,9 +108,10 @@ internal class ConnectionController(
         host: String,
         port: Int,
         timeoutMs: Long,
+        mtlsConfig: MtlsConfig? = null,
     ): Boolean {
         return runCatching {
-            connectWithTimeout(host, port, timeoutMs)
+            connectWithTimeout(host, port, timeoutMs, mtlsConfig)
             true
         }.getOrElse { error ->
             stateStore.update {

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/services/DeviceAdbAutoReconnectManager.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/services/DeviceAdbAutoReconnectManager.kt
@@ -1,6 +1,9 @@
 package io.github.miuzarte.scrcpyforandroid.services
 
 import io.github.miuzarte.scrcpyforandroid.models.DeviceShortcut
+import io.github.miuzarte.scrcpyforandroid.nativecore.MtlsConfig
+import io.github.miuzarte.scrcpyforandroid.storage.Storage.appSettings
+import io.github.miuzarte.scrcpyforandroid.storage.Storage.mtlsData
 import java.io.Closeable
 
 internal class DeviceAdbAutoReconnectManager(
@@ -8,6 +11,21 @@ internal class DeviceAdbAutoReconnectManager(
     private val stateStore: ConnectionStateStore,
     private val backgroundRunner: DeviceAdbBackgroundRunner = DeviceAdbBackgroundRunner(),
 ): Closeable {
+
+    private suspend fun buildMtlsConfigIfEnabled(): MtlsConfig? {
+        val settings = appSettings.bundleState.value
+        if (!settings.mtlsEnabled) return null
+        val data = mtlsData.bundleState.value
+        val ca = data.caCertificate.takeIf { it.isNotBlank() } ?: return null
+        val clientCert = data.clientCertificate.takeIf { it.isNotBlank() } ?: return null
+        val clientKey = data.clientPrivateKey.takeIf { it.isNotBlank() } ?: return null
+        return try {
+            MtlsConfig.fromPem(ca, clientCert, clientKey)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     suspend fun runKeepAliveLoop(
         isForeground: () -> Boolean,
         intervalMs: Long,
@@ -22,7 +40,7 @@ internal class DeviceAdbAutoReconnectManager(
             intervalMs = intervalMs,
             keepAliveCheck = { _, _ -> controller.keepAliveCheck(keepAliveTimeoutMs) },
             reconnect = { host, port ->
-                controller.connectWithTimeout(host, port, connectTimeoutMs)
+                controller.connectWithTimeout(host, port, connectTimeoutMs, buildMtlsConfigIfEnabled())
             },
             onReconnectSuccess = { host, port ->
                 controller.markKeepAliveReconnectSuccess(host, port)
@@ -71,7 +89,7 @@ internal class DeviceAdbAutoReconnectManager(
             discoverConnectService = discoverConnectService,
             onMdnsPortChanged = onMdnsPortChanged,
             connectKnownShortcut = { device, addressTarget ->
-                if (!controller.runAutoAdbConnect(addressTarget.host, addressTarget.port, connectTimeoutMs)) {
+                if (!controller.runAutoAdbConnect(addressTarget.host, addressTarget.port, connectTimeoutMs, buildMtlsConfigIfEnabled())) {
                     false
                 } else {
                     controller.handleAdbConnected(
@@ -84,7 +102,7 @@ internal class DeviceAdbAutoReconnectManager(
                 }
             },
             connectDiscoveredShortcut = { host, port, knownDevice ->
-                if (!controller.runAutoAdbConnect(host, port, connectTimeoutMs)) {
+                if (!controller.runAutoAdbConnect(host, port, connectTimeoutMs, buildMtlsConfigIfEnabled())) {
                     false
                 } else {
                     controller.handleAdbConnected(

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/services/DeviceAdbConnectionCoordinator.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/services/DeviceAdbConnectionCoordinator.kt
@@ -2,6 +2,7 @@ package io.github.miuzarte.scrcpyforandroid.services
 
 import android.os.Parcelable
 import io.github.miuzarte.scrcpyforandroid.models.ConnectionTarget
+import io.github.miuzarte.scrcpyforandroid.nativecore.MtlsConfig
 import io.github.miuzarte.scrcpyforandroid.nativecore.NativeAdbService
 import io.github.miuzarte.scrcpyforandroid.storage.ScrcpyOptions
 import kotlinx.coroutines.Dispatchers
@@ -27,11 +28,11 @@ internal data class DeviceAdbSessionState(
 internal class DeviceAdbConnectionCoordinator(
     private val adbService: NativeAdbService = NativeAdbService,
 ) {
-    suspend fun connectWithTimeout(host: String, port: Int, timeoutMs: Long) {
+    suspend fun connectWithTimeout(host: String, port: Int, timeoutMs: Long, mtlsConfig: MtlsConfig? = null) {
         withContext(Dispatchers.IO) {
             val resolved = resolveHost(host)
             withTimeout(timeoutMs) {
-                adbService.connect(resolved, port)
+                adbService.connect(resolved, port, mtlsConfig)
             }
         }
     }
@@ -40,6 +41,7 @@ internal class DeviceAdbConnectionCoordinator(
         addresses: List<String>,
         timeoutMs: Long,
         probeTimeoutMs: Int,
+        mtlsConfig: MtlsConfig? = null,
     ): ConnectionTarget {
         var lastError: Throwable? = null
         return withContext(Dispatchers.IO) {
@@ -48,7 +50,7 @@ internal class DeviceAdbConnectionCoordinator(
                     ?: throw IllegalStateException("Invalid address: ${addresses[0]}")
                 val resolved = resolveHost(target.host)
                 withTimeout(timeoutMs) {
-                    adbService.connect(resolved, target.port)
+                    adbService.connect(resolved, target.port, mtlsConfig)
                 }
                 return@withContext target
             }
@@ -71,7 +73,7 @@ internal class DeviceAdbConnectionCoordinator(
             for ((_, target, resolved) in candidates) {
                 try {
                     withTimeout(timeoutMs) {
-                        adbService.connect(resolved, target.port)
+                        adbService.connect(resolved, target.port, mtlsConfig)
                     }
                     return@withContext target
                 } catch (e: Exception) {

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/storage/AppSettings.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/storage/AppSettings.kt
@@ -262,6 +262,12 @@ class AppSettings(context: Context): Settings(context, "AppSettings") {
             false,
         )
 
+        // mTLS
+        val MTLS_ENABLED = Pair(
+            booleanPreferencesKey("mtls_enabled"),
+            false,
+        )
+
         // Terminal
         val TERMINAL_FONT_SIZE_SP = Pair(
             floatPreferencesKey("terminal_font_size_sp"),
@@ -350,6 +356,9 @@ class AppSettings(context: Context): Settings(context, "AppSettings") {
         val adbMdnsLanDiscovery: Boolean,
         val adbAutoLoadAppListOnConnect: Boolean,
 
+        // mTLS
+        val mtlsEnabled: Boolean,
+
         // Terminal
         val terminalFontSizeSp: Float,
         val terminalFontDisplayName: String,
@@ -413,6 +422,9 @@ class AppSettings(context: Context): Settings(context, "AppSettings") {
         bundleField(ADB_AUTO_RECONNECT_PAIRED_DEVICE) { it.adbAutoReconnectPairedDevice },
         bundleField(ADB_MDNS_LAN_DISCOVERY) { it.adbMdnsLanDiscovery },
         bundleField(ADB_AUTO_LOAD_APP_LIST_ON_CONNECT) { it.adbAutoLoadAppListOnConnect },
+
+        // mTLS
+        bundleField(MTLS_ENABLED) { it.mtlsEnabled },
 
         // Terminal
         bundleField(TERMINAL_FONT_SIZE_SP) { it.terminalFontSizeSp },
@@ -482,6 +494,9 @@ class AppSettings(context: Context): Settings(context, "AppSettings") {
         adbAutoReconnectPairedDevice = preferences.read(ADB_AUTO_RECONNECT_PAIRED_DEVICE),
         adbMdnsLanDiscovery = preferences.read(ADB_MDNS_LAN_DISCOVERY),
         adbAutoLoadAppListOnConnect = preferences.read(ADB_AUTO_LOAD_APP_LIST_ON_CONNECT),
+
+        // mTLS
+        mtlsEnabled = preferences.read(MTLS_ENABLED),
 
         // Terminal
         terminalFontSizeSp = preferences.read(TERMINAL_FONT_SIZE_SP),

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/storage/MtlsData.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/storage/MtlsData.kt
@@ -1,0 +1,83 @@
+package io.github.miuzarte.scrcpyforandroid.storage
+
+import android.content.Context
+import android.os.Parcelable
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.parcelize.Parcelize
+
+class MtlsData(context: Context): Settings(context, "MtlsData") {
+    companion object {
+        val CA_CERTIFICATE = Pair(
+            stringPreferencesKey("ca_certificate"),
+            "",
+        )
+        val CA_CERTIFICATE_FILE_NAME = Pair(
+            stringPreferencesKey("ca_certificate_file_name"),
+            "",
+        )
+        val CLIENT_CERTIFICATE = Pair(
+            stringPreferencesKey("client_certificate"),
+            "",
+        )
+        val CLIENT_PRIVATE_KEY = Pair(
+            stringPreferencesKey("client_private_key"),
+            "",
+        )
+        val CLIENT_CERT_FILE_NAME = Pair(
+            stringPreferencesKey("client_cert_file_name"),
+            "",
+        )
+        val CLIENT_KEY_FILE_NAME = Pair(
+            stringPreferencesKey("client_key_file_name"),
+            "",
+        )
+    }
+
+    val caCertificate by setting(CA_CERTIFICATE)
+    val caCertificateFileName by setting(CA_CERTIFICATE_FILE_NAME)
+    val clientCertificate by setting(CLIENT_CERTIFICATE)
+    val clientPrivateKey by setting(CLIENT_PRIVATE_KEY)
+    val clientCertFileName by setting(CLIENT_CERT_FILE_NAME)
+    val clientKeyFileName by setting(CLIENT_KEY_FILE_NAME)
+
+    @Parcelize
+    data class Bundle(
+        val caCertificate: String,
+        val caCertificateFileName: String,
+        val clientCertificate: String,
+        val clientPrivateKey: String,
+        val clientCertFileName: String,
+        val clientKeyFileName: String,
+    ): Parcelable {
+    }
+
+    private val bundleFields = arrayOf<BundleField<Bundle>>(
+        bundleField(CA_CERTIFICATE) { it.caCertificate },
+        bundleField(CA_CERTIFICATE_FILE_NAME) { it.caCertificateFileName },
+        bundleField(CLIENT_CERTIFICATE) { it.clientCertificate },
+        bundleField(CLIENT_PRIVATE_KEY) { it.clientPrivateKey },
+        bundleField(CLIENT_CERT_FILE_NAME) { it.clientCertFileName },
+        bundleField(CLIENT_KEY_FILE_NAME) { it.clientKeyFileName },
+    )
+
+    val bundleState: StateFlow<Bundle> = createBundleState(::bundleFromPreferences)
+
+    private fun bundleFromPreferences(preferences: Preferences) = Bundle(
+        caCertificate = preferences.read(CA_CERTIFICATE),
+        caCertificateFileName = preferences.read(CA_CERTIFICATE_FILE_NAME),
+        clientCertificate = preferences.read(CLIENT_CERTIFICATE),
+        clientPrivateKey = preferences.read(CLIENT_PRIVATE_KEY),
+        clientCertFileName = preferences.read(CLIENT_CERT_FILE_NAME),
+        clientKeyFileName = preferences.read(CLIENT_KEY_FILE_NAME),
+    )
+
+    suspend fun loadBundle() = loadBundle(::bundleFromPreferences)
+
+    suspend fun saveBundle(new: Bundle) = saveBundle(bundleState.value, new, bundleFields)
+
+    suspend fun updateBundle(transform: (Bundle) -> Bundle) {
+        saveBundle(transform(bundleState.value))
+    }
+}

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/storage/Storage.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/storage/Storage.kt
@@ -9,4 +9,5 @@ object Storage {
     val scrcpyOptions: ScrcpyOptions by lazy { ScrcpyOptions(AppRuntime.context) }
     val scrcpyProfiles: ScrcpyProfiles by lazy { ScrcpyProfiles(AppRuntime.context) }
     val adbClientData: AdbClientData by lazy { AdbClientData(AppRuntime.context) }
+    val mtlsData: MtlsData by lazy { MtlsData(AppRuntime.context) }
 }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -237,6 +237,20 @@
     <string name="pref_warning_list_apps">--list-apps 操作可能非常耗时（特别是在息屏状态下），启用后可能导致连接设备后阻塞过久！</string>
     <string name="pref_cannot_open_settings">无法打开设置</string>
 
+    <!-- Settings - mTLS -->
+    <string name="section_mtls">mTLS 认证</string>
+    <string name="pref_title_mtls_enabled">启用 mTLS</string>
+    <string name="pref_summary_mtls_enabled">通过反向代理（如 nginx）连接时使用双向 TLS 认证</string>
+    <string name="pref_title_mtls_ca_cert">CA 证书</string>
+    <string name="pref_title_mtls_client_cert">客户端证书（PKCS12）</string>
+    <string name="pref_mtls_not_imported">未导入</string>
+    <string name="pref_mtls_imported">已导入</string>
+    <string name="pref_mtls_ca_imported">CA 证书已导入：%1$s</string>
+    <string name="pref_mtls_pkcs12_imported">PKCS12 已导入：%1$s</string>
+    <string name="pref_mtls_import_failed">mTLS 导入失败：%1$s</string>
+    <string name="pref_mtls_certs_cleared">mTLS 证书已清除</string>
+    <string name="pref_mtls_clear">清除 mTLS 证书</string>
+
     <!-- Settings - Terminal -->
     <string name="section_terminal">终端</string>
     <string name="pref_title_terminal_font_size">终端字号</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,6 +237,20 @@
     <string name="pref_warning_list_apps">--list-apps may be very time-consuming (especially when screen is off); enabling may cause excessive blocking after connecting to the device!</string>
     <string name="pref_cannot_open_settings">Cannot open settings</string>
 
+    <!-- Settings - mTLS -->
+    <string name="section_mtls">mTLS Authentication</string>
+    <string name="pref_title_mtls_enabled">Enable mTLS</string>
+    <string name="pref_summary_mtls_enabled">Use mutual TLS authentication when connecting through a reverse proxy (e.g. nginx)</string>
+    <string name="pref_title_mtls_ca_cert">CA Certificate</string>
+    <string name="pref_title_mtls_client_cert">Client Certificate (PKCS12)</string>
+    <string name="pref_mtls_not_imported">Not imported</string>
+    <string name="pref_mtls_imported">Imported</string>
+    <string name="pref_mtls_ca_imported">CA certificate imported: %1$s</string>
+    <string name="pref_mtls_pkcs12_imported">PKCS12 imported: %1$s</string>
+    <string name="pref_mtls_import_failed">mTLS import failed: %1$s</string>
+    <string name="pref_mtls_certs_cleared">mTLS certificates cleared</string>
+    <string name="pref_mtls_clear">Clear mTLS certificates</string>
+
     <!-- Settings - Terminal -->
     <string name="section_terminal">Terminal</string>
     <string name="pref_title_terminal_font_size">Terminal font size</string>

--- a/doc/mtls-deployment.md
+++ b/doc/mtls-deployment.md
@@ -1,0 +1,134 @@
+# mTLS 部署指南
+
+通过 nginx stream 模块实现 mTLS (双向 TLS) 鉴权，将内网 ADB 设备安全暴露到公网。
+
+## 架构
+
+```
+手机 App ──mTLS──▶ nginx (stream) ──TCP──▶ 内网 ADB 设备
+```
+
+- nginx 在 TLS 层验证客户端证书，验证通过后将 TCP 流量原样转发到内网 ADB
+- ADB 协议本身不受影响，mTLS 仅作用于传输层
+
+## 1. 安装 nginx stream 模块
+
+```bash
+sudo apt install libnginx-mod-stream
+```
+
+## 2. 生成证书
+
+```bash
+sudo mkdir -p /etc/nginx/ssl/mTLS
+
+# CA 证书 (自签名根证书)
+sudo openssl req -x509 -newkey rsa:4096 \
+    -keyout /etc/nginx/ssl/mTLS/ca.key \
+    -out /etc/nginx/ssl/mTLS/ca.crt -days 3650 -nodes \
+    -subj "/CN=ADB mTLS CA/O=ScrcpyForAndroid"
+
+# 服务器证书 (由 CA 签发，CN 填你的域名)
+sudo openssl req -newkey rsa:2048 \
+    -keyout /etc/nginx/ssl/mTLS/server.key \
+    -out /etc/nginx/ssl/mTLS/server.csr -nodes \
+    -subj "/CN=your.domain.com"
+sudo openssl x509 -req -in /etc/nginx/ssl/mTLS/server.csr \
+    -CA /etc/nginx/ssl/mTLS/ca.crt -CAkey /etc/nginx/ssl/mTLS/ca.key \
+    -CAcreateserial -out /etc/nginx/ssl/mTLS/server.crt -days 365
+
+# 客户端证书 (由 CA 签发，供 App 导入)
+sudo openssl req -newkey rsa:2048 \
+    -keyout /etc/nginx/ssl/mTLS/client.key \
+    -out /etc/nginx/ssl/mTLS/client.csr -nodes \
+    -subj "/CN=adb-client"
+sudo openssl x509 -req -in /etc/nginx/ssl/mTLS/client.csr \
+    -CA /etc/nginx/ssl/mTLS/ca.crt -CAkey /etc/nginx/ssl/mTLS/ca.key \
+    -CAcreateserial -out /etc/nginx/ssl/mTLS/client.crt -days 365
+
+# 打包为 PKCS12 (供 App 导入，密码可自定义)
+sudo openssl pkcs12 -export \
+    -in /etc/nginx/ssl/mTLS/client.crt \
+    -inkey /etc/nginx/ssl/mTLS/client.key \
+    -out /etc/nginx/ssl/mTLS/client.p12 \
+    -name "adb-client" -legacy
+
+# 清理临时文件 & 设置权限
+sudo rm /etc/nginx/ssl/mTLS/server.csr /etc/nginx/ssl/mTLS/client.csr
+sudo chmod 600 /etc/nginx/ssl/mTLS/*.key
+sudo chmod 644 /etc/nginx/ssl/mTLS/*.crt /etc/nginx/ssl/mTLS/*.p12
+```
+
+## 3. nginx 配置
+
+### 加载 stream 模块
+
+确认 `/etc/nginx/modules-enabled/` 下已有 `50-mod-stream.conf`：
+
+```
+load_module modules/ngx_stream_module.so;
+```
+
+### 创建 stream 配置
+
+`/etc/nginx/stream.conf`：
+
+```nginx
+stream {
+    upstream adb_backend {
+        server 192.168.3.15:5555;  # 内网 ADB 设备地址
+    }
+
+    server {
+        listen 5555 ssl;  # 公网监听端口
+
+        ssl_certificate         /etc/nginx/ssl/mTLS/server.crt;
+        ssl_certificate_key     /etc/nginx/ssl/mTLS/server.key;
+        ssl_client_certificate  /etc/nginx/ssl/mTLS/ca.crt;
+        ssl_verify_client       on;  # 强制验证客户端证书
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+
+        proxy_pass adb_backend;
+        proxy_connect_timeout 10s;
+        proxy_timeout 300s;
+    }
+}
+```
+
+### nginx.conf 顶层 include
+
+在 `nginx.conf` 的 `events {}` 块之后、`http {}` 块之前添加：
+
+```nginx
+include /etc/nginx/stream.conf;
+```
+
+> **注意**：stream 块的 `listen` 端口不能与 http 块的端口冲突。
+
+### 验证 & 重载
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+## 4. App 端配置
+
+1. 将 `ca.crt` 和 `client.p12` 传输到手机
+2. 打开 App → 设置 → mTLS 认证
+3. 启用 mTLS 开关
+4. 导入 CA 证书 (`ca.crt`)
+5. 导入客户端证书 (`client.p12`，PKCS12 格式)
+6. 连接地址填写 `your.domain.com:5555`
+
+## 5. 防火墙
+
+确保公网端口（示例中为 5555）已放行。
+
+## 安全说明
+
+- CA 私钥 (`ca.key`) 请妥善保管，不要泄露
+- 客户端证书可按需吊销或更换
+- 服务器证书到期后需重新签发
+- 建议定期轮换证书


### PR DESCRIPTION
## 概述

通过 nginx stream 模块实现 mTLS (双向 TLS) 鉴权，将内网 ADB 设备安全暴露到公网。

手机 App ──mTLS──▶ nginx (stream) ──TCP──▶ 内网 ADB 设备
> 本人不太懂安卓开发，因为想实现远程访问内网 ADB 设备，直接转发到公网会不太安全，想到 mTLS 这个方案，并使用 AI 实现了该功能。如有打扰表示抱歉
## 改动

**新增文件:**
- `MtlsConfig.kt` - SSLContext 构建，客户端证书 + trust-all 服务器验证
- `MtlsData.kt` - DataStore 持久化 CA 证书和 PKCS12 客户端证书
- `doc/mtls-deployment.md` - 部署文档

**修改文件:**
- `DirectAdbClient.kt` - mTLS 连接路径、recvMsg() 数据长度校验防 OOM
- `NativeAdbService.kt` / `ConnectionController.kt` / `DeviceAdbConnectionCoordinator.kt` / `DeviceAdbAutoReconnectManager.kt` - MtlsConfig 参数穿透
- `DeviceTabViewModel.kt` - 连接时构建 MtlsConfig，失败显示 snackbar 而非闪退
- `AppSettings.kt` - MTLS_ENABLED 开关
- `Storage.kt` - 注册 MtlsData
- `SettingsScreen.kt` - mTLS 证书管理 UI
- `strings.xml` (en/zh) - mTLS 相关字符串

**无新增依赖**，使用项目已有的 BouncyCastle 和 Conscrypt 库。

## 使用方法

详见 `doc/mtls-deployment.md`

---

> 本人不太懂安卓开发，因为想实现远程访问内网 ADB 设备，直接转发到公网会不太安全，想到 mTLS 这个方案，并使用 AI 实现了该功能。如有打扰表示抱歉。