### PR TITLE
feat: 分析Scrcpy.kt的controlStream问题

### DIFF
--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/scrcpy/Scrcpy.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/scrcpy/Scrcpy.kt
@@ -1117,7 +1117,7 @@ class Scrcpy(
                 )
 
                 val controlWriter = controlStream?.let { stream ->
-                    ControlWriter(DataOutputStream(stream.outputStream))
+                    ControlWriter(DataOutputStream(BufferedOutputStream(stream.outputStream)))
                 }
                 val controlInput = controlStream?.let { stream ->
                     if (stream === firstStream) firstInput


### PR DESCRIPTION
```
根据对代码的完整追踪，问题的根因非常明确。

根因分析
核心问题：ControlWriter 未缓冲，每次写入触发独立的 ADB WRTE 包
以 injectTouch 为例，追踪一次调用的完整 I/O 路径：


Plain Text

ControlWriter.injectTouch()
  → DataOutputStream.writeByte(TYPE)     → OutStream.write(1 byte) → sendMsg(WRTE, 1B) → TCP flush
  → DataOutputStream.writeByte(action)   → OutStream.write(1 byte) → sendMsg(WRTE, 1B) → TCP flush
  → DataOutputStream.writeLong(ptrId)    → OutStream.write ×8      → sendMsg(WRTE, 1B) ×8 → TCP flush ×8
  → writePosition(x, y, sw, sh)          → OutStream.write ×12     → sendMsg(WRTE, 1B) ×12 → TCP flush ×12
  → DataOutputStream.writeShort(pressure) → OutStream.write ×2     → sendMsg(WRTE, 1B) ×2 → TCP flush ×2
  → DataOutputStream.writeInt(buttons)   → OutStream.write ×4      → sendMsg(WRTE, 1B) ×4 → TCP flush ×4
  → DataOutputStream.writeInt(btn)       → OutStream.write ×4      → sendMsg(WRTE, 1B) ×4 → TCP flush ×4
  → output.flush()                       → OutStream.flush()       → no-op
1 次 injectTouch = 32 个 WRTE 包 = 32 次 TCP flush。每个 WRTE 包 24 字节头 + 1 字节数据 = 25 字节，实际有效载荷仅 3.2%。

为什么快速滑动/缩放会导致 stream closed
快速手势时每秒可产生 60+ 个触摸事件，对应 1920+ 个 WRTE/秒。每个 WRTE 都要：

竞争 DirectAdbConnection.sendMsg() 的 @Synchronized 锁（第 838 行）
分配 24 字节 ByteBuffer、计算 CRC
写入 TCP 并 立即 flush（tcpNoDelay = true，第 589 行）
同时 readLoop 线程也需要 sendMsg 来回复 OKAY/CLSE，两个线程争抢同一把锁，导致：

发送侧：大量微型 WRTE 淹没 adbd，超出其接收缓冲区限制 → adbd 发送 CLSE 关闭流
接收侧：readLoop 被 sendMsg 锁阻塞，无法及时处理入站消息 → 异常退出 → forceClose() 所有流
无论哪种路径，最终 closed = true，后续写入抛出 IOException("ADB stream closed")。

对比：读取端有缓冲，写入端没有
第 1018 行：DataInputStream(BufferedInputStream(firstStream.inputStream)) 第 1119 行：ControlWriter(DataOutputStream(stream.outputStream)) ← 无缓冲

修复
添加 BufferedOutputStream，将 32 个 WRTE 合并为 1 个：


Kotlin

// 修复前 (Scrcpy.kt:1119-1121)
val controlWriter = controlStream?.let { stream ->
    ControlWriter(DataOutputStream(stream.outputStream))
}

// 修复后
val controlWriter = controlStream?.let { stream ->
    ControlWriter(DataOutputStream(BufferedOutputStream(stream.outputStream)))
}
加上 BufferedOutputStream 后，ControlWriter 的 writeByte/writeInt 等调用只写入内存缓冲区，直到 output.flush() 时才一次性调用 OutStream.write(buf, 0, count) 发送单个 WRTE 包。OutStream.flush() 虽是空操作，但数据已在 write() 调用中发出，不影响正确性。

效果：每秒 1920 个 WRTE → 60 个 WRTE，降低 32 倍，彻底消除 adbd 过载问题。
```