### PR TITLE
fix: Status bar color when the application is opened

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,7 +10,7 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>


### PR DESCRIPTION
修改前:
<img width="1080" height="2400" alt="S60710-12481719" src="https://github.com/user-attachments/assets/1b9e1cfa-9789-49c5-967d-7271aec519b2" />

修改后打开软件时紫色状态栏应该变透明(沉浸)
该问题只会在安卓12以前出现