### PR TITLE
fix: 锁屏密码填充界面不跟随应用语言设置

### DIFF
--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/LockscreenPasswordActivity.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/LockscreenPasswordActivity.kt
@@ -2,6 +2,7 @@ package io.github.miuzarte.scrcpyforandroid
 
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
@@ -42,6 +43,7 @@ import io.github.miuzarte.scrcpyforandroid.ui.contextClick
 import io.github.miuzarte.scrcpyforandroid.ui.createThemeController
 import io.github.miuzarte.scrcpyforandroid.ui.rememberBlurBackdrop
 import kotlinx.coroutines.*
+import java.util.Locale
 import top.yukonga.miuix.kmp.basic.*
 import top.yukonga.miuix.kmp.blur.layerBackdrop
 import top.yukonga.miuix.kmp.icon.MiuixIcons
@@ -58,6 +60,19 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.textStyles
 
 class LockscreenPasswordActivity: FragmentActivity() {
+    override fun attachBaseContext(newBase: Context) {
+        val languageTag = MainActivity.getAppLanguageTag(newBase)
+        val wrappedContext =
+            if (languageTag.isNotEmpty()) {
+                val config = Configuration(newBase.resources.configuration)
+                config.setLocale(Locale.forLanguageTag(languageTag))
+                newBase.createConfigurationContext(config)
+            } else {
+                newBase
+            }
+        super.attachBaseContext(wrappedContext)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)


### PR DESCRIPTION
## 问题描述

在应用内切换语言后，锁屏密码填充界面（`LockscreenPasswordActivity`）仍显示中文，未跟随应用语言设置。

## 复现步骤

1. 在应用设置中切换语言为英语
2. 打开锁屏密码填充界面

## 预期行为

界面文案正常显示为英语（与应用内其他界面一致）

## 实际行为

界面文案仍是中文（跟随系统语言，而不是应用内选择的语言）

## 环境

- 系统：Android 15（HyperOS 3）
- 设备：小米 10
- 版本：v0.5.3

## 原因

主界面 `MainActivity` 已通过 `attachBaseContext` 应用应用内语言（`getAppLanguageTag` + `createConfigurationContext`），但 `LockscreenPasswordActivity` 作为独立启动的 Activity（从锁屏快捷入口打开），缺少同样的语言应用逻辑，因此界面语言跟随系统而非应用内设置。

## 修复

为 `LockscreenPasswordActivity` 补上 `attachBaseContext`，复用 `MainActivity.getAppLanguageTag`：

```kotlin
override fun attachBaseContext(newBase: Context) {
    val languageTag = MainActivity.getAppLanguageTag(newBase)
    val wrappedContext =
        if (languageTag.isNotEmpty()) {
            val config = Configuration(newBase.resources.configuration)
            config.setLocale(Locale.forLanguageTag(languageTag))
            newBase.createConfigurationContext(config)
        } else {
            newBase
        }
    super.attachBaseContext(wrappedContext)
}
```

## 验证

已在小米 10（Android 15 HyperOS 3）上基于本分支真机验证：切换语言为英语后，锁屏密码填充界面正常显示英文。