### PR TITLE
fix: 文件管理跳转路径/创建文件夹输入框光标错乱

### DIFF
--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/pages/FileManagerScreen.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/pages/FileManagerScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
@@ -595,6 +597,14 @@ private fun PathJumpDialog(
     onConfirm: () -> Unit,
 ) {
     val haptic = LocalHapticFeedback.current
+    var textFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(path))
+    }
+    LaunchedEffect(path) {
+        if (textFieldValue.text != path) {
+            textFieldValue = TextFieldValue(path, TextRange(path.length))
+        }
+    }
 
     OverlayDialog(
         show = show,
@@ -604,8 +614,11 @@ private fun PathJumpDialog(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(UiSpacing.ContentVertical)) {
             TextField(
-                value = path,
-                onValueChange = onPathChange,
+                value = textFieldValue,
+                onValueChange = {
+                    textFieldValue = it
+                    onPathChange(it.text)
+                },
                 // label = "/storage/emulated/0",
                 // useLabelAsPlaceholder = true,
             )
@@ -643,6 +656,14 @@ private fun CreateFolderDialog(
     onConfirm: () -> Unit,
 ) {
     val haptic = LocalHapticFeedback.current
+    var textFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(folderName))
+    }
+    LaunchedEffect(folderName) {
+        if (textFieldValue.text != folderName) {
+            textFieldValue = TextFieldValue(folderName, TextRange(folderName.length))
+        }
+    }
 
     OverlayDialog(
         show = show,
@@ -652,8 +673,11 @@ private fun CreateFolderDialog(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(UiSpacing.ContentVertical)) {
             TextField(
-                value = folderName,
-                onValueChange = onFolderNameChange,
+                value = textFieldValue,
+                onValueChange = {
+                    textFieldValue = it
+                    onFolderNameChange(it.text)
+                },
                 label = stringResource(R.string.fm_label_new_folder),
                 useLabelAsPlaceholder = true,
             )


### PR DESCRIPTION
## 问题描述

文件管理页面中，"跳转路径"和"创建文件夹"弹窗的输入框存在光标错乱问题：光标在末尾时输入，新字符会被插入到错误位置，连续输入还会出现字符顺序错乱。

## 复现步骤

1. 打开文件管理页面
2. 点击右上角更多菜单
3. 点击"跳转路径"或"创建文件夹"
4. 跳转路径输入框末尾输入 `/123`，创建文件夹输入框输入 `123`

## 预期行为

- 跳转路径输入框显示：`/storage/emulated/0/123`
- 创建文件夹输入框显示：`123`

## 实际行为

- 跳转路径输入框显示：`/storage/emulated/0123/`（`/` 被排到末尾）
- 创建文件夹输入框显示：`231`（字符顺序错乱）

## 环境

- 系统：Android 15（HyperOS 3）
- 设备：小米 10
- 版本：v0.5.3

## 原因

两个弹窗都使用了受控 `String` 重载的 `TextField`（`value: String, onValueChange: (String) -> Unit`）。在使用 IME 组合输入（中文/系统输入法常见）时，内部 `TextFieldValue` 的 selection 会在重组过程中被重置，导致下一个字符插入到过期位置，快速连续输入时甚至出现字符乱序。

## 修复

改用 `TextFieldValue` 受控重载并保存状态，显式同步外部值，以 `PathJumpDialog` 为例：

```kotlin
var textFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
    mutableStateOf(TextFieldValue(path))
}
LaunchedEffect(path) {
    if (textFieldValue.text != path) {
        textFieldValue = TextFieldValue(path, TextRange(path.length))
    }
}
TextField(
    value = textFieldValue,
    onValueChange = {
        textFieldValue = it
        onPathChange(it.text)
    },
    ...
)
```

`CreateFolderDialog` 采用相同模式。

## 验证

已在小米 10（Android 15 HyperOS 3）上基于本分支真机验证：跳转路径末尾输入 `/123` 正确显示 `/storage/emulated/0/123`，创建文件夹输入 `123` 不再乱序。