### PR TITLE
fix: crash when creating lock-screen password on Android 10

### DIFF
--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/password/BiometricGate.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/password/BiometricGate.kt
@@ -2,11 +2,13 @@ package io.github.miuzarte.scrcpyforandroid.password
 
 import android.app.KeyguardManager
 import android.content.Context
+import android.os.Build
 import android.os.Looper
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
+import io.github.miuzarte.scrcpyforandroid.R
 import io.github.miuzarte.scrcpyforandroid.services.AppRuntime
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.concurrent.atomic.AtomicLong
@@ -18,11 +20,19 @@ object BiometricGate {
         BiometricManager.Authenticators.BIOMETRIC_STRONG or
                 BiometricManager.Authenticators.DEVICE_CREDENTIAL
 
+    private val allowedAuthenticators: Int
+        get() =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                ALLOWED_AUTHENTICATORS
+            } else {
+                BiometricManager.Authenticators.BIOMETRIC_STRONG
+            }
+
     private val sessionIds = AtomicLong(0L)
 
     fun canAuthenticate(): Boolean {
         return BiometricManager.from(AppRuntime.context)
-            .canAuthenticate(ALLOWED_AUTHENTICATORS) == BiometricManager.BIOMETRIC_SUCCESS
+            .canAuthenticate(allowedAuthenticators) == BiometricManager.BIOMETRIC_SUCCESS
     }
 
     fun isDeviceSecure(): Boolean {
@@ -76,9 +86,14 @@ object BiometricGate {
 
         prompt.authenticate(
             BiometricPrompt.PromptInfo.Builder()
-                .setAllowedAuthenticators(ALLOWED_AUTHENTICATORS)
+                .setAllowedAuthenticators(allowedAuthenticators)
                 .setTitle(title)
                 .setSubtitle(subtitle)
+                .apply {
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                        setNegativeButtonText(activity.getString(R.string.button_cancel))
+                    }
+                }
                 .build(),
         )
 


### PR DESCRIPTION
## 问题描述

在 Android 10（API 29）设备上，打开锁屏密码填充界面并创建新密码时，App 直接闪退。

## 根因

BiometricGate 使用 BiometricManager.Authenticators.BIOMETRIC_STRONG or DEVICE_CREDENTIAL 作为允许的认证方式。该组合在 API 29 上不受支持，BiometricPrompt.PromptInfo.Builder.build() 会抛出 IllegalArgumentException: Authenticator combination is unsupported on API 29，导致崩溃。

## 修复方案

按 API 级别分级：

- API 30+ 保持原有的 BIOMETRIC_STRONG | DEVICE_CREDENTIAL，支持系统 PIN/密码作为备选认证
- API < 30 仅使用 BIOMETRIC_STRONG，并补充 setNegativeButtonText(Cancel) 提供取消按钮（API < 30 无 setDeviceCredentialAllowed 时必须有负按钮）

## 验证

- LG G710（Android 10 / API 29）：创建密码不再闪退，生物识别认证正常弹出，认证通过后密码保存成功
- 小米 10（Android 15 / API 35）：创建密码功能回归正常，行为与原实现一致