### PR TITLE
fix: restrict floating bottom bar to Android 13+ to avoid crash

### DIFF
--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/pages/SettingsScreen.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/pages/SettingsScreen.kt
@@ -3,6 +3,7 @@ package io.github.miuzarte.scrcpyforandroid.pages
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.provider.OpenableColumns
 import androidx.activity.compose.LocalActivity
@@ -424,29 +425,36 @@ fun SettingsPage(
                         )
                     },
                 )
-                SwitchPreference(
-                    title = stringResource(R.string.pref_title_floating_bottom_bar),
-                    summary = stringResource(R.string.pref_summary_floating_bottom_bar),
-                    checked = asBundle.floatingBottomBar,
-                    onCheckedChange = {
-                        asBundle = asBundle.copy(
-                            floatingBottomBar = it,
-                        )
-                    },
-                )
-                AnimatedVisibility(asBundle.floatingBottomBar && asBundle.blur) {
-                    Column {
-                        SwitchPreference(
-                            title = stringResource(R.string.pref_title_liquid_glass),
-                            summary = stringResource(R.string.pref_summary_liquid_glass),
-                            checked = asBundle.floatingBottomBar && asBundle.blur
-                                    && asBundle.floatingBottomBarBlur,
-                            onCheckedChange = {
-                                asBundle = asBundle.copy(
-                                    floatingBottomBarBlur = it,
-                                )
-                            },
-                        )
+                // 悬浮底栏依赖 InteractiveHighlight，其内部构造 android.graphics.RuntimeShader（API 33+ 引入），
+                // 低版本开启会闪退，故仅 Android 13+ 显示该开关
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && asBundle.floatingBottomBar) {
+                    asBundle = asBundle.copy(floatingBottomBar = false, floatingBottomBarBlur = false)
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    SwitchPreference(
+                        title = stringResource(R.string.pref_title_floating_bottom_bar),
+                        summary = stringResource(R.string.pref_summary_floating_bottom_bar),
+                        checked = asBundle.floatingBottomBar,
+                        onCheckedChange = {
+                            asBundle = asBundle.copy(
+                                floatingBottomBar = it,
+                            )
+                        },
+                    )
+                    AnimatedVisibility(asBundle.floatingBottomBar && asBundle.blur) {
+                        Column {
+                            SwitchPreference(
+                                title = stringResource(R.string.pref_title_liquid_glass),
+                                summary = stringResource(R.string.pref_summary_liquid_glass),
+                                checked = asBundle.floatingBottomBar && asBundle.blur
+                                        && asBundle.floatingBottomBarBlur,
+                                onCheckedChange = {
+                                    asBundle = asBundle.copy(
+                                        floatingBottomBarBlur = it,
+                                    )
+                                },
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 问题描述

在 Android 13 以下（如 Android 10）打开 App 并开启悬浮底栏后，App 立即闪退，且设置被持久化后每次启动主界面都会崩溃，只能清除应用数据才能恢复。

## 根因

悬浮底栏使用 `InteractiveHighlight`（`miuix/animation`），其内部无条件构造 `android.graphics.RuntimeShader`。`RuntimeShader` 是 API 33+ 才引入的类，在 Android 13 以下会抛出 `ClassNotFoundException`，导致崩溃。

## 修复方案

按评审意见简化，仅改动设置页（`SettingsScreen.kt`，共 1 个文件）：

- `SDK_INT < 33` 时直接隐藏"悬浮底栏"开关（连同"液态玻璃"子项一起隐藏），不引入额外文案
- 隐藏开关的同时清掉残留的 `floatingBottomBar` / `floatingBottomBarBlur` 值，避免此前开启过的用户升级后在低版本上仍因残留设置触发崩溃

`MainScreen.kt` 保持原样，不做任何版本判断。

## 验证

- LG G710（Android 10 / API 29）：设置页不再显示悬浮底栏开关，App 正常打开不闪退，此前曾开启过也能正常启动
- 小米 10（Android 15 / API 35）：悬浮底栏开关正常显示，开启后正常显示，功能回归正常