### PR TITLE
fix: make AppRuntime string resources follow in-app language setting

### DIFF
--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/services/AppRuntime.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/services/AppRuntime.kt
@@ -1,10 +1,13 @@
 package io.github.miuzarte.scrcpyforandroid.services
 
 import android.content.Context
+import android.content.res.Configuration
 import androidx.annotation.StringRes
+import io.github.miuzarte.scrcpyforandroid.MainActivity
 import io.github.miuzarte.scrcpyforandroid.models.ConnectionTarget
 import io.github.miuzarte.scrcpyforandroid.nativecore.AdbMdnsDiscoverer
 import io.github.miuzarte.scrcpyforandroid.scrcpy.Scrcpy
+import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -110,6 +113,18 @@ object AppRuntime {
         dismissNewest = dismissNewest,
     )
 
-    fun stringResource(@StringRes resId: Int) = appContext.getString(resId)
-    fun stringResource(@StringRes resId: Int, vararg args: Any) = appContext.getString(resId, *args)
+    // 应用内语言设置只包裹了 Activity 的 base context，
+    // 这里用同样的方式包装 application context，使 snackbar 等全局文案跟随应用内语言
+    private fun localizedContext(): Context {
+        val languageTag = MainActivity.getAppLanguageTag(appContext)
+        return if (languageTag.isEmpty()) appContext
+        else appContext.createConfigurationContext(
+            Configuration(appContext.resources.configuration).apply {
+                setLocale(Locale.forLanguageTag(languageTag))
+            }
+        )
+    }
+
+    fun stringResource(@StringRes resId: Int) = localizedContext().getString(resId)
+    fun stringResource(@StringRes resId: Int, vararg args: Any) = localizedContext().getString(resId, *args)
 }


### PR DESCRIPTION
## 问题描述

应用内语言设置为 English 时，snackbar 等全局通知文案仍跟随**系统语言**显示，不跟随应用内语言设置。

## 根因

`AppRuntime.stringResource` 使用 **application context** 解析字符串资源（`appContext.getString(...)`），而应用内语言设置只通过 `MainActivity.attachBaseContext` 包裹了 Activity 的 base context——application context 未被包裹，其资源永远跟随系统语言。

所有通过 `AppRuntime.snackbar(...)` / `AppRuntime.stringResource(...)` 输出的文案（连接、断开、配对等全局通知）都受影响。

## 修复方案

在 `AppRuntime` 中新增 `localizedContext()`：按 `MainActivity.getAppLanguageTag` 读取应用内语言设置，用 `createConfigurationContext` 包装 application context（与 `attachBaseContext` 同款逻辑），两个 `stringResource` 重载改走该路径：

- 语言 tag 为空（跟随系统）时行为与原来完全一致
- 每次调用现读现包：应用内切换语言后，下一条通知立即生效，无需重启
- 全部几十处 `AppRuntime.snackbar / stringResource` 调用点一次性修正

## 验证

- 小米 10（Android 15 / API 35）：应用内切 English 后 snackbar 显示英文；切回"跟随系统"恢复中文；切换后无需重启立即生效