### PR TITLE
fix: add ACCESS_LOCAL_NETWORK runtime permission for Android 17 LAN discovery

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,16 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- 局域网 mDNS 设备发现：Android 17+ 用 ACCESS_LOCAL_NETWORK，Android 13-16 用 NEARBY_WIFI_DEVICES，Android 12 用位置权限 -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="33" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/MainActivity.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/MainActivity.kt
@@ -1,13 +1,16 @@
 package io.github.miuzarte.scrcpyforandroid
 
+import android.Manifest
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.fragment.app.FragmentActivity
 import io.github.miuzarte.scrcpyforandroid.pages.MainScreen
@@ -61,6 +64,9 @@ class MainActivity: FragmentActivity() {
             }
         }
 
+        // 请求附近设备/局域网 mDNS 发现所需的运行时权限
+        requestNearbyDevicePermissions()
+
         enableEdgeToEdge()
 
         setContent {
@@ -77,6 +83,59 @@ class MainActivity: FragmentActivity() {
     override fun onDestroy() {
         AppScreenOn.unregister(window)
         super.onDestroy()
+    }
+
+    /**
+     * 请求附近设备 / 局域网 mDNS 设备发现所需的运行时权限。
+     * 授权后应用才会出现在系统"附近的设备"设置中，且 NsdManager 才能正常扫描局域网 ADB 设备。
+     */
+    private fun requestNearbyDevicePermissions() {
+        val permissions = buildList {
+            if (Build.VERSION.SDK_INT >= 37) {
+                // Android 17+: 本地网络访问权限（门控局域网 mDNS 发现和局域网连接，默认阻止）
+                add(Manifest.permission.ACCESS_LOCAL_NETWORK)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && Build.VERSION.SDK_INT < 37
+            ) {
+                // Android 13-16: 附近 WiFi 设备发现（替代位置权限）
+                add(Manifest.permission.NEARBY_WIFI_DEVICES)
+            }
+            if (Build.VERSION.SDK_INT in Build.VERSION_CODES.S..Build.VERSION_CODES.S_V2) {
+                // Android 12: NsdManager mDNS 发现需要精确位置权限
+                add(Manifest.permission.ACCESS_FINE_LOCATION)
+            }
+        }.toTypedArray()
+
+        if (permissions.isEmpty()) return
+
+        val needRequest = permissions.any {
+            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
+        }
+        if (needRequest) {
+            requestPermissions(permissions, REQUEST_CODE_NEARBY_PERMISSIONS)
+        }
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_CODE_NEARBY_PERMISSIONS) {
+            val granted = permissions.filterIndexed { i, _ ->
+                grantResults.getOrNull(i) == PackageManager.PERMISSION_GRANTED
+            }
+            val denied = permissions.toList() - granted.toSet()
+            if (denied.isNotEmpty()) {
+                android.util.Log.w(
+                    "MainActivity",
+                    "附近设备权限被拒绝: $denied, 局域网设备发现可能不可用"
+                )
+            }
+        }
     }
 
     private fun applyMainOrientationPolicy() {
@@ -103,6 +162,7 @@ class MainActivity: FragmentActivity() {
 
     internal companion object {
         private const val PHONE_LANDSCAPE_LOCK_ASPECT_RATIO = 16f / 9f
+        private const val REQUEST_CODE_NEARBY_PERMISSIONS = 1001
 
         private const val LOCALE_PREFS = "locale_cache"
         private const val KEY_LANGUAGE_TAG = "language_tag"


### PR DESCRIPTION
## 问题
升级到 Android 17（MagicOS 11）后，局域网设备发现失败，无法连接局域网内的 ADB 设备。外网映射连接正常。

## 原因
Android 17（API 37）引入了 `ACCESS_LOCAL_NETWORK` 运行时权限，对 targetSdk ≥ 37 的应用默认阻止局域网访问，包括 mDNS 设备发现（NsdManager）和局域网套接字连接。

本项目 targetSdk = 37，原代码未声明和请求该权限，导致局域网 mDNS 扫描被系统拦截。

## 修改
1. **AndroidManifest.xml**:
   - 新增 `ACCESS_LOCAL_NETWORK`（Android 17+ 局域网访问必需）
   - 新增 `NEARBY_WIFI_DEVICES`（Android 13-16 向下兼容）
   - 新增 `ACCESS_FINE_LOCATION`（Android 12 mDNS 发现需要，maxSdk=32）
   - 新增 ACCESS_WIFI_STATE / CHANGE_WIFI_STATE

2. **MainActivity.kt**:
   - 新增 `requestNearbyDevicePermissions()`，按 Android 版本智能请求所需运行时权限
   - 新增 `onRequestPermissionsResult` 回调
   - 在 onCreate 中调用权限请求

## 测试
- 设备：荣耀 MagicOS 11（Android 17 / API 37）
- 修复前：局域网 mDNS 发现失败，无法连接局域网设备
- 修复后：首次启动弹出本地网络权限请求，允许后正常发现和连接局域网设备