### PR TITLE
fix: add ACCESS_LOCAL_NETWORK runtime permission for Android 17

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!-- Android 17+: 本地网络访问权限（门控局域网 mDNS 发现和局域网连接，默认阻止） -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
-    <!-- Android 17+: 本地网络访问权限（门控局域网 mDNS 发现和局域网连接，默认阻止） -->
+    <!-- Android 17+: 本地网络访问权限 (门控局域网 mDNS 发现和局域网连接, 部分设备默认阻止) -->
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     <application

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/MainActivity.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/MainActivity.kt
@@ -1,13 +1,16 @@
 package io.github.miuzarte.scrcpyforandroid
 
+import android.Manifest
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.fragment.app.FragmentActivity
 import io.github.miuzarte.scrcpyforandroid.pages.MainScreen
@@ -61,6 +64,9 @@ class MainActivity: FragmentActivity() {
             }
         }
 
+        // 请求附近设备/局域网 mDNS 发现所需的运行时权限
+        requestNearbyDevicePermissions()
+
         enableEdgeToEdge()
 
         setContent {
@@ -77,6 +83,36 @@ class MainActivity: FragmentActivity() {
     override fun onDestroy() {
         AppScreenOn.unregister(window)
         super.onDestroy()
+    }
+
+    /**
+     * 请求 Android 17+ 本地网络访问运行时权限。
+     * 授权后 NsdManager 才能正常扫描局域网 ADB 设备。
+     */
+    private fun requestNearbyDevicePermissions() {
+        if (Build.VERSION.SDK_INT < 37) return
+
+        val permission = Manifest.permission.ACCESS_LOCAL_NETWORK
+        if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) return
+
+        requestPermissions(arrayOf(permission), REQUEST_CODE_NEARBY_PERMISSIONS)
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_CODE_NEARBY_PERMISSIONS
+            && grantResults.firstOrNull() != PackageManager.PERMISSION_GRANTED
+        ) {
+            android.util.Log.w(
+                "MainActivity",
+                "本地网络权限被拒绝，局域网设备发现可能不可用"
+            )
+        }
     }
 
     private fun applyMainOrientationPolicy() {
@@ -103,6 +139,7 @@ class MainActivity: FragmentActivity() {
 
     internal companion object {
         private const val PHONE_LANDSCAPE_LOCK_ASPECT_RATIO = 16f / 9f
+        private const val REQUEST_CODE_NEARBY_PERMISSIONS = 1001
 
         private const val LOCALE_PREFS = "locale_cache"
         private const val KEY_LANGUAGE_TAG = "language_tag"

--- a/app/src/main/java/io/github/miuzarte/scrcpyforandroid/MainActivity.kt
+++ b/app/src/main/java/io/github/miuzarte/scrcpyforandroid/MainActivity.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.fragment.app.FragmentActivity
@@ -85,34 +86,27 @@ class MainActivity: FragmentActivity() {
         super.onDestroy()
     }
 
+    private val localNetworkPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (!granted) {
+                android.util.Log.w(
+                    "MainActivity",
+                    "本地网络权限被拒绝，局域网设备发现可能不可用"
+                )
+            }
+        }
+
     /**
      * 请求 Android 17+ 本地网络访问运行时权限。
      * 授权后 NsdManager 才能正常扫描局域网 ADB 设备。
      */
     private fun requestNearbyDevicePermissions() {
-        if (Build.VERSION.SDK_INT < 37) return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) return
 
         val permission = Manifest.permission.ACCESS_LOCAL_NETWORK
         if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) return
 
-        requestPermissions(arrayOf(permission), REQUEST_CODE_NEARBY_PERMISSIONS)
-    }
-
-    @Deprecated("Deprecated in Java")
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray,
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == REQUEST_CODE_NEARBY_PERMISSIONS
-            && grantResults.firstOrNull() != PackageManager.PERMISSION_GRANTED
-        ) {
-            android.util.Log.w(
-                "MainActivity",
-                "本地网络权限被拒绝，局域网设备发现可能不可用"
-            )
-        }
+        localNetworkPermissionLauncher.launch(permission)
     }
 
     private fun applyMainOrientationPolicy() {
@@ -139,7 +133,6 @@ class MainActivity: FragmentActivity() {
 
     internal companion object {
         private const val PHONE_LANDSCAPE_LOCK_ASPECT_RATIO = 16f / 9f
-        private const val REQUEST_CODE_NEARBY_PERMISSIONS = 1001
 
         private const val LOCALE_PREFS = "locale_cache"
         private const val KEY_LANGUAGE_TAG = "language_tag"


### PR DESCRIPTION
## 问题
升级到 Android 17（MagicOS 11）后，局域网设备发现失败，无法连接局域网内的 ADB 设备。外网连接正常。

## 原因
Android 17（API 37）引入了 `ACCESS_LOCAL_NETWORK` 运行时权限，对 targetSdk ≥ 37 的应用默认阻止局域网访问，包括 mDNS 设备发现（NsdManager）。本项目 targetSdk = 37，未声明和请求该权限，导致局域网扫描被系统拦截。

## 修改
- `AndroidManifest.xml`：声明 `ACCESS_LOCAL_NETWORK` 权限
- `MainActivity.kt`：在 onCreate 中请求该运行时权限（仅 Android 17+）

## 测试
- 设备：荣耀 MagicOS 11（Android 17）
- 修复前：局域网 mDNS 发现失败
- 修复后：首次启动弹出本地网络权限请求，允许后正常发现和连接局域网设备